### PR TITLE
KPP Compatibility with Touhou Terrain submod

### DIFF
--- a/common/event_modifiers/touhou_event_modifiers.txt
+++ b/common/event_modifiers/touhou_event_modifiers.txt
@@ -1092,6 +1092,10 @@ th_estate_burghers_swamp_developers_jungle_modifier = {
 	local_development_cost = -0.45
 }
 
+th_estate_burghers_swamp_developers_ravine_modifier = {
+	local_development_cost = -0.40
+}
+
 #TGU event modifiers
 tgu_sided_with_great_tengu = {
 	all_estate_loyalty_equilibrium = -0.25

--- a/localisation/touhou_estates_l_english.yml
+++ b/localisation/touhou_estates_l_english.yml
@@ -523,6 +523,8 @@
  desc_th_estate_burghers_swamp_developers_farmlands_modifier: "This province is a place of many kappa projects to increase its development and infrastructure."
  th_estate_burghers_swamp_developers_jungle_modifier: "Swamp Development"
  desc_th_estate_burghers_swamp_developers_jungle_modifier: "This province is a place of many kappa projects to increase its development and infrastructure."
+ th_estate_burghers_swamp_developers_ravine_modifier: "Swamp Development"
+ desc_th_estate_burghers_swamp_developers_ravine_modifier: "This province is a place of many kappa projects to increase its development and infrastructure."
  ###ESTATE INTERACTIONS###
  TH_DOES_NOT_CARE: "Does not care about the Diet: §R$VAL$§!"
  ###ESTATE AGENDAS###


### PR DESCRIPTION
Added a new terrain dev cost reduction that's tied with Touhou Terrain Pictures submod. It only triggers if the submod is activated